### PR TITLE
Update to use public Net::DNS API

### DIFF
--- a/jdresolve
+++ b/jdresolve
@@ -857,7 +857,12 @@ sub checkresponse {
 				# For each DNS answer, check the data received
 				if ($type eq 'H') {
 					if (defined $_->{ptrdname}) {
+						if ($_->isa('Net::DNS::RR::PTR')) { 
+							# Fix for a new version of Net::DNS 
+							$hosts{$query}{NAME} = $_->rdatastr();
+						} else {
 						$hosts{$query}{NAME} = $_->{ptrdname};
+						}
 						$hosts{$query}{RESOLVED} = 'N';
 
 						$resolved = 1;


### PR DESCRIPTION
Currently jdresolve is completely unusable. Modern version of Net::DNS changed its internals and now user get Perl garbage like Net::DNS::....=HASH(0x1a7d060) instead of hostnames.

This patch make use of official interface and restores functionality of jdresolve.
